### PR TITLE
feat: restrict registration to authenticated admins

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,14 +1,18 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Post, UseGuards } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
 import { Public } from './public.decorator';
+import { Roles } from './roles.decorator';
+import { RolesGuard } from './roles.guard';
+import { Role } from '../users/role.enum';
 
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
-  @Public()
+  @UseGuards(RolesGuard)
+  @Roles(Role.ADMIN)
   @Post('register')
   register(@Body() dto: RegisterDto) {
     return this.authService.register(dto);

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -5,6 +5,7 @@ import { UsersModule } from '../users/users.module';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { JwtStrategy } from './jwt.strategy';
+import { RolesGuard } from './roles.guard';
 
 @Module({
   imports: [
@@ -15,7 +16,7 @@ import { JwtStrategy } from './jwt.strategy';
       signOptions: { expiresIn: '1h' },
     }),
   ],
-  providers: [AuthService, JwtStrategy],
+  providers: [AuthService, JwtStrategy, RolesGuard],
   controllers: [AuthController],
 })
 export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -19,8 +19,9 @@ export class AuthService {
       username: dto.username,
       email: dto.email,
       password: hashed,
+      role: dto.role,
     });
-    return { id: user.id, username: user.username, email: user.email };
+    return { id: user.id, username: user.username, email: user.email, role: user.role };
   }
 
   async validateUser(email: string, password: string) {
@@ -40,7 +41,7 @@ export class AuthService {
     if (!user) {
       throw new UnauthorizedException();
     }
-    const payload = { sub: user.id, email: user.email };
+    const payload = { sub: user.id, email: user.email, role: user.role };
     return {
       access_token: await this.jwtService.signAsync(payload),
     };

--- a/src/auth/dto/register.dto.ts
+++ b/src/auth/dto/register.dto.ts
@@ -1,4 +1,5 @@
-import { IsEmail, IsString, MinLength } from 'class-validator';
+import { IsEmail, IsEnum, IsString, MinLength } from 'class-validator';
+import { Role } from '../../users/role.enum';
 
 export class RegisterDto {
   @IsString()
@@ -11,4 +12,7 @@ export class RegisterDto {
   @IsString()
   @MinLength(6)
   password: string;
+
+  @IsEnum(Role)
+  role: Role;
 }

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -13,6 +13,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: any) {
-    return { userId: payload.sub, email: payload.email };
+    return { userId: payload.sub, email: payload.email, role: payload.role };
   }
 }

--- a/src/auth/roles.decorator.ts
+++ b/src/auth/roles.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+import { Role } from '../users/role.enum';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: Role[]) => SetMetadata(ROLES_KEY, roles);

--- a/src/auth/roles.guard.spec.ts
+++ b/src/auth/roles.guard.spec.ts
@@ -1,0 +1,33 @@
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { RolesGuard } from './roles.guard';
+import { Role } from '../users/role.enum';
+
+describe('RolesGuard', () => {
+  const reflector = new Reflector();
+  const guard = new RolesGuard(reflector);
+
+  const createContext = (role: Role): ExecutionContext => {
+    return {
+      switchToHttp: () => ({ getRequest: () => ({ user: { role } }) }),
+      getHandler: () => ({}),
+      getClass: () => ({}),
+    } as unknown as ExecutionContext;
+  };
+
+  it('allows access for required role', () => {
+    jest
+      .spyOn(reflector, 'getAllAndOverride')
+      .mockReturnValue([Role.ADMIN]);
+    const context = createContext(Role.ADMIN);
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('denies access for missing role', () => {
+    jest
+      .spyOn(reflector, 'getAllAndOverride')
+      .mockReturnValue([Role.ADMIN]);
+    const context = createContext(Role.USER);
+    expect(() => guard.canActivate(context)).toThrow(ForbiddenException);
+  });
+});

--- a/src/auth/roles.guard.ts
+++ b/src/auth/roles.guard.ts
@@ -1,0 +1,24 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { ROLES_KEY } from './roles.decorator';
+import { Role } from '../users/role.enum';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<Role[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (!requiredRoles || requiredRoles.length === 0) {
+      return true;
+    }
+    const { user } = context.switchToHttp().getRequest();
+    if (!user || !requiredRoles.includes(user.role)) {
+      throw new ForbiddenException('Insufficient role');
+    }
+    return true;
+  }
+}

--- a/src/users/role.enum.ts
+++ b/src/users/role.enum.ts
@@ -1,0 +1,5 @@
+export enum Role {
+  ADMIN = 'ADMIN',
+  USER = 'USER',
+  MODERATOR = 'MODERATOR',
+}

--- a/src/users/user.schema.ts
+++ b/src/users/user.schema.ts
@@ -1,5 +1,6 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document } from 'mongoose';
+import { Role } from './role.enum';
 
 @Schema()
 export class User extends Document {
@@ -11,6 +12,9 @@ export class User extends Document {
 
   @Prop({ required: true })
   password: string;
+
+  @Prop({ required: true, enum: Role, default: Role.USER })
+  role: Role;
 }
 
 export const UserSchema = SchemaFactory.createForClass(User);


### PR DESCRIPTION
## Summary
- add Role enum and role field to users
- require ADMIN role to access registration endpoint
- include user role in JWT payload and guard against insufficient role
- add unit tests for role-based guard

## Testing
- `npm test`
- `npm run test:e2e` *(fails: Exceeded timeout of 5000 ms for a hook)*

------
https://chatgpt.com/codex/tasks/task_e_689375f3e05c832b9b2dbf3488c6fdbd