### PR TITLE
feat(feedback): add file upload endpoint

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2,10 +2,14 @@ import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
 import { AppModule } from './app.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import * as express from 'express';
+import { join } from 'path';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.useGlobalPipes(new ValidationPipe({ transform: true }));
+
+  app.use('/public/files', express.static(join(process.cwd(), 'uploads')));
 
   app.enableCors({
     origin: ['http://localhost:4200'], // agrega otros orígenes si usas más

--- a/src/public/feedback/feedback.controller.ts
+++ b/src/public/feedback/feedback.controller.ts
@@ -1,26 +1,178 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Post,
+  UploadedFile,
+  UseInterceptors,
+  ParseFilePipe,
+  MaxFileSizeValidator,
+  FileTypeValidator,
+  Logger,
+} from '@nestjs/common';
 import {
   ApiBody,
+  ApiConsumes,
   ApiCreatedResponse,
-  ApiOperation,
   ApiTags,
 } from '@nestjs/swagger';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { diskStorage } from 'multer';
+import { randomUUID } from 'crypto';
+import { join, extname, relative } from 'path';
+import * as fs from 'fs';
 import { Public } from '../../auth/public.decorator';
 import { CreateFeedbackDto } from './dto/create-feedback.dto';
-import { Feedback } from './schemas/feedback.schema';
 import { FeedbackService } from './feedback.service';
+import { StorageService } from '../../storage/storage.service';
 
-@ApiTags('Feedback')
+interface UploadedFile {
+  path: string;
+  mimetype: string;
+  size: number;
+  originalname: string;
+  filename: string;
+}
+
+/**
+ * curl -X POST http://localhost:3000/public/feedback \
+ *   -F "lastName=Doe" \
+ *   -F "firstName=Jane" \
+ *   -F "email=jane@example.com" \
+ *   -F "description=Hay baches en la calle 10" \
+ *   -F "phone=0999999999" \
+ *   -F "type=complaint" \
+ *   -F "contacted=true" \
+ *   -F "latitude=-0.1807" \
+ *   -F "longitude=-78.4678" \
+ *   -F "address=Quito, EC" \
+ *   -F "attachment=@/ruta/imagen.png;type=image/png"
+ */
+@ApiTags('Public/Feedback')
 @Controller('public/feedback')
 export class FeedbackController {
-  constructor(private readonly feedbackService: FeedbackService) {}
+  private readonly logger = new Logger(FeedbackController.name);
+
+  constructor(
+    private readonly feedbackService: FeedbackService,
+    private readonly storageService: StorageService,
+  ) {}
 
   @Public()
   @Post()
-  @ApiOperation({ summary: 'Create feedback entry' })
-  @ApiBody({ type: CreateFeedbackDto })
-  @ApiCreatedResponse({ type: Feedback })
-  async create(@Body() dto: CreateFeedbackDto): Promise<Feedback> {
-    return this.feedbackService.create(dto);
+  @ApiConsumes('multipart/form-data')
+  @UseInterceptors(
+    FileInterceptor('attachment', {
+      storage: diskStorage({
+        destination: (req, file, cb) => {
+          const now = new Date();
+          const uploadPath = join(
+            process.cwd(),
+            'uploads',
+            now.getFullYear().toString(),
+            (now.getMonth() + 1).toString().padStart(2, '0'),
+          );
+          fs.mkdirSync(uploadPath, { recursive: true });
+          cb(null, uploadPath);
+        },
+        filename: (req, file, cb) => {
+          const ext = extname(file.originalname).toLowerCase();
+          cb(null, `${randomUUID()}${ext}`);
+        },
+      }),
+    }),
+  )
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        lastName: { type: 'string' },
+        firstName: { type: 'string' },
+        email: { type: 'string' },
+        description: { type: 'string' },
+        phone: { type: 'string' },
+        type: {
+          type: 'string',
+          enum: ['complaint', 'suggestion', 'compliment'],
+        },
+        contacted: { type: 'boolean' },
+        latitude: { type: 'number' },
+        longitude: { type: 'number' },
+        address: { type: 'string' },
+        attachment: { type: 'string', format: 'binary', nullable: true },
+      },
+    },
+  })
+  @ApiCreatedResponse({
+    schema: {
+      type: 'object',
+      properties: {
+        id: { type: 'string', format: 'uuid' },
+        lastName: { type: 'string' },
+        firstName: { type: 'string' },
+        email: { type: 'string' },
+        description: { type: 'string' },
+        phone: { type: 'string' },
+        type: { type: 'string' },
+        contacted: { type: 'boolean' },
+        latitude: { type: 'number' },
+        longitude: { type: 'number' },
+        address: { type: 'string' },
+        attachment: {
+          type: 'object',
+          nullable: true,
+          properties: {
+            url: { type: 'string' },
+            mimeType: { type: 'string' },
+            size: { type: 'number' },
+            originalName: { type: 'string' },
+          },
+        },
+        createdAt: { type: 'string', format: 'date-time' },
+      },
+    },
+  })
+  async create(
+    @Body() dto: CreateFeedbackDto,
+    @UploadedFile(
+      new ParseFilePipe({
+        fileIsRequired: false,
+        validators: [
+          new MaxFileSizeValidator({ maxSize: 10 * 1024 * 1024 }),
+          new FileTypeValidator({
+            fileType:
+              /^(image\/jpeg|image\/png|image\/webp|video\/mp4|application\/pdf)$/,
+          }),
+        ],
+      }),
+    )
+    file?: UploadedFile,
+  ) {
+    this.logger.log('Handling feedback creation');
+    try {
+      let attachmentMeta;
+      if (file) {
+        const relativePath = relative(
+          join(process.cwd(), 'uploads'),
+          file.path,
+        ).replace(/\\/g, '/');
+        const url = this.storageService.getPublicUrl(relativePath);
+        attachmentMeta = {
+          url,
+          mimeType: file.mimetype,
+          size: file.size,
+          originalName: file.originalname,
+          filename: file.filename,
+        };
+      }
+      const result = await this.feedbackService.createFeedback(
+        dto,
+        attachmentMeta,
+      );
+      this.logger.log(`Feedback created: ${result.id}`);
+      return result;
+    } catch (err) {
+      this.logger.error('Error creating feedback', err.stack);
+      throw err;
+    }
   }
 }

--- a/src/public/feedback/feedback.module.ts
+++ b/src/public/feedback/feedback.module.ts
@@ -1,16 +1,17 @@
 import { Module } from '@nestjs/common';
-import { MongooseModule } from '@nestjs/mongoose';
 import { FeedbackController } from './feedback.controller';
 import { FeedbackService } from './feedback.service';
-import { Feedback, FeedbackSchema } from './schemas/feedback.schema';
+import { FilesystemStorageService } from '../../storage/filesystem.storage';
+import { StorageService } from '../../storage/storage.service';
 
 @Module({
-  imports: [
-    MongooseModule.forFeature([
-      { name: Feedback.name, schema: FeedbackSchema },
-    ]),
-  ],
   controllers: [FeedbackController],
-  providers: [FeedbackService],
+  providers: [
+    FeedbackService,
+    {
+      provide: StorageService,
+      useClass: FilesystemStorageService,
+    },
+  ],
 })
 export class FeedbackModule {}

--- a/src/storage/filesystem.storage.ts
+++ b/src/storage/filesystem.storage.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@nestjs/common';
+import { StorageService } from './storage.service';
+
+@Injectable()
+export class FilesystemStorageService implements StorageService {
+  getPublicUrl(relativePath: string): string {
+    return `/public/files/${relativePath.replace(/\\/g, '/')}`;
+  }
+}

--- a/src/storage/storage.service.ts
+++ b/src/storage/storage.service.ts
@@ -1,0 +1,3 @@
+export abstract class StorageService {
+  abstract getPublicUrl(relativePath: string): string;
+}


### PR DESCRIPTION
## Summary
- add filesystem storage service with public URL helper
- handle feedback creation with optional attachment metadata
- expose POST `/public/feedback` as multipart endpoint and serve uploaded files under `/public/files`

## Testing
- `npm test`
- `npm run lint` *(fails: Unsafe assignment errors, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb7f973d20832ba3bf57169e71584c