### PR TITLE
Add personal data collection and default employee role

### DIFF
--- a/src/auth/dto/register.dto.ts
+++ b/src/auth/dto/register.dto.ts
@@ -1,5 +1,4 @@
-import { IsEmail, IsEnum, IsString, MinLength } from 'class-validator';
-import { Role } from '../../users/role.enum';
+import { IsEmail, IsString, MinLength } from 'class-validator';
 
 export class RegisterDto {
   @IsString()
@@ -13,6 +12,12 @@ export class RegisterDto {
   @MinLength(6)
   password: string;
 
-  @IsEnum(Role)
-  role: Role;
+  @IsString()
+  name: string;
+
+  @IsString()
+  lastname: string;
+
+  @IsString()
+  dni: string;
 }

--- a/src/auth/roles.guard.spec.ts
+++ b/src/auth/roles.guard.spec.ts
@@ -16,18 +16,14 @@ describe('RolesGuard', () => {
   };
 
   it('allows access for required role', () => {
-    jest
-      .spyOn(reflector, 'getAllAndOverride')
-      .mockReturnValue([Role.ADMIN]);
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue([Role.ADMIN]);
     const context = createContext(Role.ADMIN);
     expect(guard.canActivate(context)).toBe(true);
   });
 
   it('denies access for missing role', () => {
-    jest
-      .spyOn(reflector, 'getAllAndOverride')
-      .mockReturnValue([Role.ADMIN]);
-    const context = createContext(Role.USER);
+    jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue([Role.ADMIN]);
+    const context = createContext(Role.EMPLOYEE);
     expect(() => guard.canActivate(context)).toThrow(ForbiddenException);
   });
 });

--- a/src/modules/feedback/feedback.service.spec.ts
+++ b/src/modules/feedback/feedback.service.spec.ts
@@ -6,7 +6,11 @@ describe('FeedbackService', () => {
   let service: FeedbackService;
 
   beforeEach(() => {
-    service = new FeedbackService();
+    const feedbackModel = jest.fn().mockImplementation((data) => ({
+      ...data,
+      save: jest.fn(),
+    }));
+    service = new FeedbackService(feedbackModel as any);
   });
 
   const dto: CreateFeedbackDto = {

--- a/src/users/personal-data.schema.ts
+++ b/src/users/personal-data.schema.ts
@@ -1,0 +1,19 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document, Types } from 'mongoose';
+
+@Schema()
+export class PersonalData extends Document {
+  @Prop({ required: true })
+  name: string;
+
+  @Prop({ required: true })
+  lastname: string;
+
+  @Prop({ required: true })
+  dni: string;
+
+  @Prop({ type: Types.ObjectId, ref: 'User', required: true })
+  user: Types.ObjectId;
+}
+
+export const PersonalDataSchema = SchemaFactory.createForClass(PersonalData);

--- a/src/users/role.enum.ts
+++ b/src/users/role.enum.ts
@@ -2,4 +2,5 @@ export enum Role {
   ADMIN = 'ADMIN',
   USER = 'USER',
   MODERATOR = 'MODERATOR',
+  EMPLOYEE = 'EMPLOYEE',
 }

--- a/src/users/user.schema.ts
+++ b/src/users/user.schema.ts
@@ -1,5 +1,5 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import { Document } from 'mongoose';
+import { Document, Types } from 'mongoose';
 import { Role } from './role.enum';
 
 @Schema()
@@ -13,8 +13,14 @@ export class User extends Document {
   @Prop({ required: true })
   password: string;
 
-  @Prop({ required: true, enum: Role, default: Role.USER })
+  @Prop({ required: true, enum: Role, default: Role.EMPLOYEE })
   role: Role;
+
+  @Prop({ default: true })
+  isFirstLogin: boolean;
+
+  @Prop({ type: Types.ObjectId, ref: 'PersonalData' })
+  personalData: Types.ObjectId;
 }
 
 export const UserSchema = SchemaFactory.createForClass(User);

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,10 +1,16 @@
 import { Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 import { User, UserSchema } from './user.schema';
+import { PersonalData, PersonalDataSchema } from './personal-data.schema';
 import { UsersService } from './users.service';
 
 @Module({
-  imports: [MongooseModule.forFeature([{ name: User.name, schema: UserSchema }])],
+  imports: [
+    MongooseModule.forFeature([
+      { name: User.name, schema: UserSchema },
+      { name: PersonalData.name, schema: PersonalDataSchema },
+    ]),
+  ],
   providers: [UsersService],
   exports: [UsersService],
 })

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -2,14 +2,29 @@ import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { User } from './user.schema';
+import { PersonalData } from './personal-data.schema';
 
 @Injectable()
 export class UsersService {
-  constructor(@InjectModel(User.name) private userModel: Model<User>) {}
+  constructor(
+    @InjectModel(User.name) private userModel: Model<User>,
+    @InjectModel(PersonalData.name)
+    private personalDataModel: Model<PersonalData>,
+  ) {}
 
-  async create(data: Partial<User>): Promise<User> {
-    const created = new this.userModel(data);
-    return created.save();
+  async create(
+    userData: Partial<User>,
+    personalData: Partial<PersonalData>,
+  ): Promise<User> {
+    const createdUser = new this.userModel(userData);
+    await createdUser.save();
+    const personal = new this.personalDataModel({
+      ...personalData,
+      user: createdUser._id,
+    });
+    await personal.save();
+    createdUser.personalData = personal._id;
+    return createdUser.save();
   }
 
   async findByEmail(email: string): Promise<User | null> {


### PR DESCRIPTION
## Summary
- Track first login state with `isFirstLogin` flag on users
- Store basic personal data in dedicated `PersonalData` collection linked to users
- Automatically assign `EMPLOYEE` role to new accounts

## Testing
- `npm test`
- `npm run lint` *(fails: 24 errors, 3 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b8389978832baacd401c21baf7bd