### PR TITLE
feat: add company CRUD

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,7 @@ import { UsersModule } from './users/users.module';
 import { JwtAuthGuard } from './auth/jwt-auth.guard';
 import { FeedbackModule } from './modules/feedback/feedback.module';
 import { FeedbackModule as PrivateFeedbackModule } from './private/feedback/feedback.module';
+import { CompanyModule } from './private/company/company.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { FeedbackModule as PrivateFeedbackModule } from './private/feedback/feed
     UsersModule,
     FeedbackModule,
     PrivateFeedbackModule,
+    CompanyModule,
   ],
   controllers: [],
   providers: [

--- a/src/modules/company/schemas/company.schema.ts
+++ b/src/modules/company/schemas/company.schema.ts
@@ -1,0 +1,20 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { ApiProperty } from '@nestjs/swagger';
+import { Document } from 'mongoose';
+
+@Schema({ collection: 'companies' })
+export class Company extends Document {
+  @ApiProperty()
+  @Prop({ required: true })
+  name: string;
+
+  @ApiProperty()
+  @Prop()
+  description: string;
+
+  @ApiProperty()
+  @Prop({ required: true })
+  status: string;
+}
+
+export const CompanySchema = SchemaFactory.createForClass(Company);

--- a/src/private/company/company.controller.ts
+++ b/src/private/company/company.controller.ts
@@ -1,0 +1,55 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+} from '@nestjs/common';
+import { ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Company } from '../../modules/company/schemas/company.schema';
+import { CompanyService } from './company.service';
+import { CreateCompanyDto } from './dto/create-company.dto';
+import { UpdateCompanyDto } from './dto/update-company.dto';
+
+@ApiTags('Company')
+@Controller('private/companies')
+export class CompanyController {
+  constructor(private readonly companyService: CompanyService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Create company' })
+  @ApiBody({ type: CreateCompanyDto })
+  create(@Body() dto: CreateCompanyDto): Promise<Company> {
+    return this.companyService.create(dto);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List companies' })
+  findAll(): Promise<Company[]> {
+    return this.companyService.findAll();
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get company by id' })
+  findOne(@Param('id') id: string): Promise<Company> {
+    return this.companyService.findOne(id);
+  }
+
+  @Patch(':id')
+  @ApiOperation({ summary: 'Update company' })
+  @ApiBody({ type: UpdateCompanyDto })
+  update(
+    @Param('id') id: string,
+    @Body() dto: UpdateCompanyDto,
+  ): Promise<Company> {
+    return this.companyService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete company' })
+  remove(@Param('id') id: string): Promise<Company> {
+    return this.companyService.remove(id);
+  }
+}

--- a/src/private/company/company.module.ts
+++ b/src/private/company/company.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import {
+  Company,
+  CompanySchema,
+} from '../../modules/company/schemas/company.schema';
+import { CompanyController } from './company.controller';
+import { CompanyService } from './company.service';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: Company.name, schema: CompanySchema }]),
+  ],
+  controllers: [CompanyController],
+  providers: [CompanyService],
+})
+export class CompanyModule {}

--- a/src/private/company/company.service.ts
+++ b/src/private/company/company.service.ts
@@ -1,0 +1,48 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { Company } from '../../modules/company/schemas/company.schema';
+import { CreateCompanyDto } from './dto/create-company.dto';
+import { UpdateCompanyDto } from './dto/update-company.dto';
+
+@Injectable()
+export class CompanyService {
+  constructor(
+    @InjectModel(Company.name) private readonly companyModel: Model<Company>,
+  ) {}
+
+  async create(dto: CreateCompanyDto): Promise<Company> {
+    const company = new this.companyModel(dto);
+    return company.save();
+  }
+
+  async findAll(): Promise<Company[]> {
+    return this.companyModel.find().exec();
+  }
+
+  async findOne(id: string): Promise<Company> {
+    const company = await this.companyModel.findById(id).exec();
+    if (!company) {
+      throw new NotFoundException(`Company with ID ${id} not found`);
+    }
+    return company;
+  }
+
+  async update(id: string, dto: UpdateCompanyDto): Promise<Company> {
+    const company = await this.companyModel
+      .findByIdAndUpdate(id, dto, { new: true })
+      .exec();
+    if (!company) {
+      throw new NotFoundException(`Company with ID ${id} not found`);
+    }
+    return company;
+  }
+
+  async remove(id: string): Promise<Company> {
+    const company = await this.companyModel.findByIdAndDelete(id).exec();
+    if (!company) {
+      throw new NotFoundException(`Company with ID ${id} not found`);
+    }
+    return company;
+  }
+}

--- a/src/private/company/dto/create-company.dto.ts
+++ b/src/private/company/dto/create-company.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+export class CreateCompanyDto {
+  @ApiProperty()
+  @IsString()
+  name: string;
+
+  @ApiProperty()
+  @IsString()
+  description: string;
+
+  @ApiProperty()
+  @IsString()
+  status: string;
+}

--- a/src/private/company/dto/update-company.dto.ts
+++ b/src/private/company/dto/update-company.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateCompanyDto } from './create-company.dto';
+
+export class UpdateCompanyDto extends PartialType(CreateCompanyDto) {}


### PR DESCRIPTION
## Summary
- add Company schema
- implement authenticated CRUD endpoints for companies
- register CompanyModule

## Testing
- `npm test`
- `npm run lint` *(fails: Unsafe assignment and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c4bf40c468832b8d9746af275b0518