### PR TITLE
feat: add email notifications for user registration

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,5 +1,16 @@
 import { UsersService } from './../users/users.service';
-import { Body, Controller, Delete, Get, Param, Patch, Post, Query, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Logger,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
@@ -9,17 +20,41 @@ import { RolesGuard } from './roles.guard';
 import { Role } from '../users/role.enum';
 import { JwtAuthGuard } from './jwt-auth.guard';
 import { ApiQuery, ApiOperation } from '@nestjs/swagger';
+import { NotificationsService } from '../notifications/notifications.service';
 
 @Controller('auth')
 export class AuthController {
-  constructor(private readonly authService: AuthService,
-    private readonly usersService: UsersService) {}
+  private readonly logger = new Logger(AuthController.name);
+
+  constructor(
+    private readonly authService: AuthService,
+    private readonly usersService: UsersService,
+    private readonly notificationsService: NotificationsService,
+  ) {}
 
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.ADMIN)
   @Post('register')
-  register(@Body() dto: RegisterDto) {
-    return this.authService.register(dto);
+  async register(@Body() dto: RegisterDto) {
+    const user = await this.authService.register(dto);
+    const { subject, html, text } = this.buildCredentialsEmailTemplate(
+      dto.username,
+      dto.password,
+    );
+    try {
+      await this.notificationsService.sendEmail({
+        to: dto.email,
+        subject,
+        html,
+        text,
+      });
+    } catch (error) {
+      this.logger.error(
+        `No se pudo enviar el correo de credenciales a ${dto.email}`,
+        error instanceof Error ? error.stack : undefined,
+      );
+    }
+    return user;
   }
 
   @UseGuards(JwtAuthGuard, RolesGuard)
@@ -70,5 +105,31 @@ export class AuthController {
     const pageNumber = parseInt(page as string, 10) || 1;
     const limitNumber = parseInt(limit as string, 10) || 10;
     return this.usersService.findAll(pageNumber, limitNumber, filters);
+  }
+
+  private buildCredentialsEmailTemplate(username: string, password: string) {
+    const subject = 'Credenciales de acceso';
+    const html = `
+      <div style="font-family: Arial, sans-serif; color: #1a1a1a;">
+        <h2>Bienvenido a Complaints & Suggestions</h2>
+        <p>Tu cuenta ha sido creada correctamente. Estas son tus credenciales de acceso:</p>
+        <ul>
+          <li><strong>Usuario:</strong> ${username}</li>
+          <li><strong>Contraseña:</strong> ${password}</li>
+        </ul>
+        <p>Te recomendamos iniciar sesión y actualizar tu contraseña cuanto antes.</p>
+        <p>Si tú no solicitaste este registro, contacta con el administrador.</p>
+      </div>
+    `;
+    const text = [
+      'Bienvenido a Complaints & Suggestions',
+      '',
+      'Tu cuenta ha sido creada correctamente.',
+      `Usuario: ${username}`,
+      `Contraseña: ${password}`,
+      '',
+      'Te recomendamos iniciar sesión y actualizar tu contraseña cuanto antes.',
+    ].join('\n');
+    return { subject, html, text };
   }
 }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -6,11 +6,13 @@ import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { JwtStrategy } from './jwt.strategy';
 import { RolesGuard } from './roles.guard';
+import { NotificationsModule } from '../notifications/notifications.module';
 
 @Module({
   imports: [
     UsersModule,
     PassportModule,
+    NotificationsModule,
     JwtModule.register({
       secret: process.env.JWT_SECRET || 'secret',
       signOptions: { expiresIn: '1h' },

--- a/src/notifications/notifications.module.ts
+++ b/src/notifications/notifications.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { NotificationsService } from './notifications.service';
+
+@Module({
+  providers: [NotificationsService],
+  exports: [NotificationsService],
+})
+export class NotificationsModule {}

--- a/src/notifications/notifications.service.ts
+++ b/src/notifications/notifications.service.ts
@@ -1,0 +1,106 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { request as httpRequest } from 'node:http';
+import { request as httpsRequest } from 'node:https';
+import { URL } from 'node:url';
+
+export interface SendEmailOptions {
+  to: string;
+  subject: string;
+  html: string;
+  text?: string;
+  from?: string;
+}
+
+@Injectable()
+export class NotificationsService {
+  private readonly logger = new Logger(NotificationsService.name);
+  private readonly apiUrl?: string;
+  private readonly apiKey?: string;
+  private readonly defaultFrom: string;
+
+  constructor() {
+    this.apiUrl = process.env.EMAIL_API_URL;
+    this.apiKey = process.env.EMAIL_API_KEY;
+    this.defaultFrom =
+      process.env.EMAIL_FROM ||
+      process.env.EMAIL_SENDER ||
+      'no-reply@complaints-suggestions.com';
+  }
+
+  async sendEmail(options: SendEmailOptions): Promise<void> {
+    if (!this.apiUrl) {
+      this.logger.warn(
+        'EMAIL_API_URL no está configurado. El correo no se enviará.',
+      );
+      return;
+    }
+
+    const url = new URL(this.apiUrl);
+    const payload = JSON.stringify({
+      to: options.to,
+      subject: options.subject,
+      html: options.html,
+      text: options.text,
+      from: options.from ?? this.defaultFrom,
+    });
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'Content-Length': Buffer.byteLength(payload).toString(),
+    };
+
+    if (this.apiKey) {
+      headers.Authorization = `Bearer ${this.apiKey}`;
+    }
+
+    const requestFn = url.protocol === 'https:' ? httpsRequest : httpRequest;
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const req = requestFn(
+          {
+            hostname: url.hostname,
+            port: url.port || (url.protocol === 'https:' ? 443 : 80),
+            path: `${url.pathname}${url.search}`,
+            method: 'POST',
+            headers,
+          },
+          (res) => {
+            const statusCode = res.statusCode ?? 0;
+            if (statusCode >= 200 && statusCode < 300) {
+              res.on('data', () => undefined);
+              res.on('end', resolve);
+            } else {
+              let body = '';
+              res.setEncoding('utf8');
+              res.on('data', (chunk) => {
+                body += chunk;
+              });
+              res.on('end', () => {
+                reject(
+                  new Error(
+                    `Email API responded with status ${statusCode}${
+                      body ? `: ${body}` : ''
+                    }`,
+                  ),
+                );
+              });
+            }
+            res.on('error', reject);
+          },
+        );
+
+        req.on('error', (error) => reject(error));
+        req.write(payload);
+        req.end();
+      });
+    } catch (error) {
+      this.logger.error(
+        `Fallo al enviar correo a ${options.to}: ${
+          error instanceof Error ? error.message : error
+        }`,
+      );
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable notifications service to handle outbound email delivery
- wire the notifications module into the authentication flow
- send a templated credentials email to new users during registration while handling failures gracefully

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cad4bcb738832b8010038e2d35eadf