### PR TITLE
feat: allow tagging companies

### DIFF
--- a/src/modules/company/schemas/company.schema.ts
+++ b/src/modules/company/schemas/company.schema.ts
@@ -17,6 +17,10 @@ export class Company extends Document {
   status: string;
 
   @ApiProperty({ type: [String], required: false, default: [] })
+  @Prop({ type: [String], default: [] })
+  tags: string[];
+
+  @ApiProperty({ type: [String], required: false, default: [] })
   @Prop({ type: [{ type: Types.ObjectId, ref: 'PersonalData' }], default: [] })
   contacts: Types.ObjectId[];
 }

--- a/src/modules/feedback/schemas/feedback.schema.ts
+++ b/src/modules/feedback/schemas/feedback.schema.ts
@@ -3,7 +3,6 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Document } from 'mongoose';
 import { FeedbackType } from '../feedback-type.enum';
 import { FeedbackStatus } from '../feedback-status.enum';
-import { FeedbackCompanyRequestDto } from 'src/private/feedback/dto/feedback-company-request.dto';
 
 @Schema({ _id: false })
 export class FeedbackStatusHistoryUser {

--- a/src/private/company/dto/create-company.dto.ts
+++ b/src/private/company/dto/create-company.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString } from 'class-validator';
+import { IsArray, IsOptional, IsString } from 'class-validator';
 
 export class CreateCompanyDto {
   @ApiProperty()
@@ -13,4 +13,10 @@ export class CreateCompanyDto {
   @ApiProperty()
   @IsString()
   status: string;
+
+  @ApiProperty({ type: [String], required: false, default: [] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  tags?: string[];
 }


### PR DESCRIPTION
## Summary
- allow the company creation DTO to accept an optional array of tag strings
- persist company tags in the Mongoose schema so they are stored with the document

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cce6b4ba30832b97803f830f09a38b