### PR TITLE
Limit dashboard data by user company

### DIFF
--- a/src/private/dashboard/dashboard.controller.ts
+++ b/src/private/dashboard/dashboard.controller.ts
@@ -1,9 +1,13 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Req } from '@nestjs/common';
 import {
   DashboardService,
   DashboardSummaryResponseDto,
 } from './dashboard.service';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Request } from 'express';
+import { JwtUserPayload } from '../../auth/interfaces/jwt-user-payload.interface';
+
+type RequestWithUser = Request & { user: JwtUserPayload };
 
 @Controller('private/dashboard')
 @ApiTags('Dashboard')
@@ -14,12 +18,16 @@ export class DashboardController {
   @ApiOperation({
     summary: 'Obtener métricas agregadas del dashboard administrativo',
   })
-  getSummary(): Promise<DashboardSummaryResponseDto> {
-    return this.dashboardService.getSummary();
+  getSummary(
+    @Req() req: RequestWithUser,
+  ): Promise<DashboardSummaryResponseDto> {
+    return this.dashboardService.getSummary(req.user);
   }
 
   @Get('feedbacks/geo')
-  async getFeedbacksGeo(): Promise<{ latitude: number; longitude: number }[]> {
-    return this.dashboardService.getFeedbacksGeo();
+  async getFeedbacksGeo(
+    @Req() req: RequestWithUser,
+  ): Promise<{ latitude: number; longitude: number }[]> {
+    return this.dashboardService.getFeedbacksGeo(req.user);
   }
 }

--- a/src/private/dashboard/dashboard.module.ts
+++ b/src/private/dashboard/dashboard.module.ts
@@ -6,11 +6,21 @@ import {
   Feedback,
   FeedbackSchema,
 } from 'src/modules/feedback/schemas/feedback.schema';
+import {
+  Company,
+  CompanySchema,
+} from 'src/modules/company/schemas/company.schema';
+import {
+  PersonalData,
+  PersonalDataSchema,
+} from 'src/users/personal-data.schema';
 
 @Module({
   imports: [
     MongooseModule.forFeature([
       { name: Feedback.name, schema: FeedbackSchema },
+      { name: Company.name, schema: CompanySchema },
+      { name: PersonalData.name, schema: PersonalDataSchema },
     ]),
   ],
   controllers: [DashboardController],


### PR DESCRIPTION
## Summary
- pass the authenticated user to dashboard endpoints so service-level filters can consider role and company
- inject company and personal data models into the dashboard service and filter dashboard metrics/geo data by the user's associated companies
- return empty metrics when a non-admin user has no linked companies while keeping aggregated statistics for admins

## Testing
- npm run lint *(fails: existing lint violations across unrelated files)*
- npx eslint src/private/dashboard/dashboard.controller.ts src/private/dashboard/dashboard.module.ts src/private/dashboard/dashboard.service.ts


------
https://chatgpt.com/codex/tasks/task_e_68d23539721c832b88d467705fca3d83