### PR TITLE
Add private CRUD modules for roles and permissions

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,8 @@ import { FeedbackModule as PrivateFeedbackModule } from './private/feedback/feed
 import { CompanyModule } from './private/company/company.module';
 import { ConfigModule } from '@nestjs/config';
 import { DashboardModule } from './private/dashboard/dashboard.module';
+import { PermissionsModule } from './private/permissions/permissions.module';
+import { RolesModule } from './private/roles/roles.module';
 
 @Module({
   imports: [
@@ -21,6 +23,8 @@ import { DashboardModule } from './private/dashboard/dashboard.module';
     FeedbackModule,
     PrivateFeedbackModule,
     CompanyModule,
+    PermissionsModule,
+    RolesModule,
     ConfigModule.forRoot({
       isGlobal: true,
     }),

--- a/src/modules/permissions/schemas/permission.schema.ts
+++ b/src/modules/permissions/schemas/permission.schema.ts
@@ -1,0 +1,22 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Document } from 'mongoose';
+
+export type PermissionStatus = 'ACT' | 'INA' | 'BLO';
+
+@Schema({ collection: 'permissions', timestamps: true })
+export class Permission extends Document {
+  @ApiProperty()
+  @Prop({ required: true, unique: true })
+  name: string;
+
+  @ApiPropertyOptional()
+  @Prop({ required: false })
+  description?: string;
+
+  @ApiProperty({ enum: ['ACT', 'INA', 'BLO'], default: 'ACT' })
+  @Prop({ required: true, enum: ['ACT', 'INA', 'BLO'], default: 'ACT' })
+  status: PermissionStatus;
+}
+
+export const PermissionSchema = SchemaFactory.createForClass(Permission);

--- a/src/modules/roles/schemas/role.schema.ts
+++ b/src/modules/roles/schemas/role.schema.ts
@@ -1,0 +1,34 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Document, Types } from 'mongoose';
+import { Permission } from '../../permissions/schemas/permission.schema';
+
+export type RoleStatus = 'ACT' | 'INA' | 'BLO';
+
+@Schema({ collection: 'roles', timestamps: true })
+export class Role extends Document {
+  @ApiProperty()
+  @Prop({ required: true, unique: true })
+  name: string;
+
+  @ApiPropertyOptional()
+  @Prop({ required: false })
+  description?: string;
+
+  @ApiProperty({ enum: ['ACT', 'INA', 'BLO'], default: 'ACT' })
+  @Prop({ required: true, enum: ['ACT', 'INA', 'BLO'], default: 'ACT' })
+  status: RoleStatus;
+
+  @ApiProperty({
+    type: [String],
+    description: 'Permission identifiers',
+    default: [],
+  })
+  @Prop({
+    type: [{ type: Types.ObjectId, ref: Permission.name }],
+    default: [],
+  })
+  permissions: Types.ObjectId[] | Permission[];
+}
+
+export const RoleSchema = SchemaFactory.createForClass(Role);

--- a/src/private/permissions/dto/create-permission.dto.ts
+++ b/src/private/permissions/dto/create-permission.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsIn, IsOptional, IsString } from 'class-validator';
+
+export class CreatePermissionDto {
+  @ApiProperty()
+  @IsString()
+  name: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiProperty({ enum: ['ACT', 'INA', 'BLO'], default: 'ACT' })
+  @IsOptional()
+  @IsIn(['ACT', 'INA', 'BLO'])
+  status?: 'ACT' | 'INA' | 'BLO';
+}

--- a/src/private/permissions/dto/update-permission.dto.ts
+++ b/src/private/permissions/dto/update-permission.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreatePermissionDto } from './create-permission.dto';
+
+export class UpdatePermissionDto extends PartialType(CreatePermissionDto) {}

--- a/src/private/permissions/permissions.controller.ts
+++ b/src/private/permissions/permissions.controller.ts
@@ -1,0 +1,61 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
+import { ApiBody, ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { Permission } from '../../modules/permissions/schemas/permission.schema';
+import { PermissionsService } from './permissions.service';
+import { CreatePermissionDto } from './dto/create-permission.dto';
+import { UpdatePermissionDto } from './dto/update-permission.dto';
+
+@ApiTags('Permissions')
+@Controller('private/permissions')
+export class PermissionsController {
+  constructor(private readonly permissionsService: PermissionsService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Create permission' })
+  @ApiBody({ type: CreatePermissionDto })
+  create(@Body() dto: CreatePermissionDto): Promise<Permission> {
+    return this.permissionsService.create(dto);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List permissions with pagination and filters' })
+  @ApiQuery({ name: 'page', required: false })
+  @ApiQuery({ name: 'limit', required: false })
+  findAll(@Query() query: Record<string, unknown>) {
+    const { page = 1, limit = 10, ...filters } = query;
+    const pageNumber = parseInt(page as string, 10) || 1;
+    const limitNumber = parseInt(limit as string, 10) || 10;
+    return this.permissionsService.findAll(pageNumber, limitNumber, filters);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get permission by id' })
+  findOne(@Param('id') id: string): Promise<Permission> {
+    return this.permissionsService.findOne(id);
+  }
+
+  @Patch(':id')
+  @ApiOperation({ summary: 'Update permission' })
+  @ApiBody({ type: UpdatePermissionDto })
+  update(
+    @Param('id') id: string,
+    @Body() dto: UpdatePermissionDto,
+  ): Promise<Permission> {
+    return this.permissionsService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete permission (soft delete to INA status)' })
+  remove(@Param('id') id: string): Promise<Permission> {
+    return this.permissionsService.remove(id);
+  }
+}

--- a/src/private/permissions/permissions.module.ts
+++ b/src/private/permissions/permissions.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import {
+  Permission,
+  PermissionSchema,
+} from '../../modules/permissions/schemas/permission.schema';
+import { PermissionsController } from './permissions.controller';
+import { PermissionsService } from './permissions.service';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: Permission.name, schema: PermissionSchema },
+    ]),
+  ],
+  controllers: [PermissionsController],
+  providers: [PermissionsService],
+})
+export class PermissionsModule {}

--- a/src/private/permissions/permissions.service.ts
+++ b/src/private/permissions/permissions.service.ts
@@ -1,0 +1,84 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { Permission } from '../../modules/permissions/schemas/permission.schema';
+import { CreatePermissionDto } from './dto/create-permission.dto';
+import { UpdatePermissionDto } from './dto/update-permission.dto';
+
+@Injectable()
+export class PermissionsService {
+  constructor(
+    @InjectModel(Permission.name)
+    private readonly permissionModel: Model<Permission>,
+  ) {}
+
+  async create(dto: CreatePermissionDto): Promise<Permission> {
+    const permission = new this.permissionModel({
+      ...dto,
+      status: dto.status ?? 'ACT',
+    });
+    await permission.save();
+    return permission;
+  }
+
+  async findAll(
+    page = 1,
+    limit = 10,
+    filters: Record<string, unknown> = {},
+  ): Promise<{
+    data: Permission[];
+    total: number;
+    page: number;
+    limit: number;
+  }> {
+    const skip = (page - 1) * limit;
+
+    const mongoFilters: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(filters)) {
+      if (typeof value === 'string') {
+        mongoFilters[key] = { $regex: value, $options: 'i' };
+      } else {
+        mongoFilters[key] = value;
+      }
+    }
+
+    const query = this.permissionModel
+      .find(mongoFilters)
+      .skip(skip)
+      .limit(limit);
+    const [data, total] = await Promise.all([
+      query.exec(),
+      this.permissionModel.countDocuments(mongoFilters).exec(),
+    ]);
+
+    return { data, total, page, limit };
+  }
+
+  async findOne(id: string): Promise<Permission> {
+    const permission = await this.permissionModel.findById(id).exec();
+    if (!permission) {
+      throw new NotFoundException(`Permission with ID ${id} not found`);
+    }
+    return permission;
+  }
+
+  async update(id: string, dto: UpdatePermissionDto): Promise<Permission> {
+    const permission = await this.permissionModel
+      .findByIdAndUpdate(id, dto, { new: true, runValidators: true })
+      .exec();
+    if (!permission) {
+      throw new NotFoundException(`Permission with ID ${id} not found`);
+    }
+    return permission;
+  }
+
+  async remove(id: string): Promise<Permission> {
+    const permission = await this.permissionModel
+      .findByIdAndUpdate(id, { status: 'INA' }, { new: true })
+      .exec();
+    if (!permission) {
+      throw new NotFoundException(`Permission with ID ${id} not found`);
+    }
+    return permission;
+  }
+}

--- a/src/private/roles/dto/create-role.dto.ts
+++ b/src/private/roles/dto/create-role.dto.ts
@@ -1,0 +1,30 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsArray,
+  IsIn,
+  IsMongoId,
+  IsOptional,
+  IsString,
+} from 'class-validator';
+
+export class CreateRoleDto {
+  @ApiProperty()
+  @IsString()
+  name: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiProperty({ enum: ['ACT', 'INA', 'BLO'], default: 'ACT' })
+  @IsOptional()
+  @IsIn(['ACT', 'INA', 'BLO'])
+  status?: 'ACT' | 'INA' | 'BLO';
+
+  @ApiProperty({ type: [String], required: false, default: [] })
+  @IsOptional()
+  @IsArray()
+  @IsMongoId({ each: true })
+  permissions?: string[];
+}

--- a/src/private/roles/dto/update-role.dto.ts
+++ b/src/private/roles/dto/update-role.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateRoleDto } from './create-role.dto';
+
+export class UpdateRoleDto extends PartialType(CreateRoleDto) {}

--- a/src/private/roles/roles.controller.ts
+++ b/src/private/roles/roles.controller.ts
@@ -1,0 +1,58 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
+import { ApiBody, ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { Role } from '../../modules/roles/schemas/role.schema';
+import { RolesService } from './roles.service';
+import { CreateRoleDto } from './dto/create-role.dto';
+import { UpdateRoleDto } from './dto/update-role.dto';
+
+@ApiTags('Roles')
+@Controller('private/roles')
+export class RolesController {
+  constructor(private readonly rolesService: RolesService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Create role' })
+  @ApiBody({ type: CreateRoleDto })
+  create(@Body() dto: CreateRoleDto): Promise<Role> {
+    return this.rolesService.create(dto);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List roles with pagination and filters' })
+  @ApiQuery({ name: 'page', required: false })
+  @ApiQuery({ name: 'limit', required: false })
+  findAll(@Query() query: Record<string, unknown>) {
+    const { page = 1, limit = 10, ...filters } = query;
+    const pageNumber = parseInt(page as string, 10) || 1;
+    const limitNumber = parseInt(limit as string, 10) || 10;
+    return this.rolesService.findAll(pageNumber, limitNumber, filters);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get role by id' })
+  findOne(@Param('id') id: string): Promise<Role> {
+    return this.rolesService.findOne(id);
+  }
+
+  @Patch(':id')
+  @ApiOperation({ summary: 'Update role' })
+  @ApiBody({ type: UpdateRoleDto })
+  update(@Param('id') id: string, @Body() dto: UpdateRoleDto): Promise<Role> {
+    return this.rolesService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete role (soft delete to INA status)' })
+  remove(@Param('id') id: string): Promise<Role> {
+    return this.rolesService.remove(id);
+  }
+}

--- a/src/private/roles/roles.module.ts
+++ b/src/private/roles/roles.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { Role, RoleSchema } from '../../modules/roles/schemas/role.schema';
+import {
+  Permission,
+  PermissionSchema,
+} from '../../modules/permissions/schemas/permission.schema';
+import { RolesController } from './roles.controller';
+import { RolesService } from './roles.service';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: Role.name, schema: RoleSchema },
+      { name: Permission.name, schema: PermissionSchema },
+    ]),
+  ],
+  controllers: [RolesController],
+  providers: [RolesService],
+})
+export class RolesModule {}

--- a/src/private/roles/roles.service.ts
+++ b/src/private/roles/roles.service.ts
@@ -1,0 +1,108 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+import { Role } from '../../modules/roles/schemas/role.schema';
+import { CreateRoleDto } from './dto/create-role.dto';
+import { UpdateRoleDto } from './dto/update-role.dto';
+
+@Injectable()
+export class RolesService {
+  constructor(
+    @InjectModel(Role.name)
+    private readonly roleModel: Model<Role>,
+  ) {}
+
+  async create(dto: CreateRoleDto): Promise<Role> {
+    const { permissions = [], status = 'ACT', ...rest } = dto;
+    const role = new this.roleModel({
+      ...rest,
+      status,
+      permissions: permissions.map((id) => new Types.ObjectId(id)),
+    });
+    await role.save();
+    await role.populate('permissions');
+    return role;
+  }
+
+  async findAll(
+    page = 1,
+    limit = 10,
+    filters: Record<string, unknown> = {},
+  ): Promise<{ data: Role[]; total: number; page: number; limit: number }> {
+    const skip = (page - 1) * limit;
+
+    const mongoFilters: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(filters)) {
+      if (key === 'permissions' && value) {
+        const ids = Array.isArray(value) ? value : [value];
+        mongoFilters[key] = {
+          $all: ids.map((id) => new Types.ObjectId(String(id))),
+        };
+        continue;
+      }
+      if (typeof value === 'string') {
+        mongoFilters[key] = { $regex: value, $options: 'i' };
+      } else {
+        mongoFilters[key] = value;
+      }
+    }
+
+    const query = this.roleModel
+      .find(mongoFilters)
+      .skip(skip)
+      .limit(limit)
+      .populate('permissions');
+
+    const [data, total] = await Promise.all([
+      query.exec(),
+      this.roleModel.countDocuments(mongoFilters).exec(),
+    ]);
+
+    return { data, total, page, limit };
+  }
+
+  async findOne(id: string): Promise<Role> {
+    const role = await this.roleModel
+      .findById(id)
+      .populate('permissions')
+      .exec();
+    if (!role) {
+      throw new NotFoundException(`Role with ID ${id} not found`);
+    }
+    return role;
+  }
+
+  async update(id: string, dto: UpdateRoleDto): Promise<Role> {
+    const updateData: Record<string, unknown> = { ...dto };
+
+    if (dto.permissions) {
+      updateData.permissions = dto.permissions.map((permissionId) =>
+        new Types.ObjectId(permissionId),
+      );
+    }
+
+    const role = await this.roleModel
+      .findByIdAndUpdate(id, updateData, {
+        new: true,
+        runValidators: true,
+      })
+      .populate('permissions')
+      .exec();
+
+    if (!role) {
+      throw new NotFoundException(`Role with ID ${id} not found`);
+    }
+    return role;
+  }
+
+  async remove(id: string): Promise<Role> {
+    const role = await this.roleModel
+      .findByIdAndUpdate(id, { status: 'INA' }, { new: true })
+      .populate('permissions')
+      .exec();
+    if (!role) {
+      throw new NotFoundException(`Role with ID ${id} not found`);
+    }
+    return role;
+  }
+}


### PR DESCRIPTION
## Summary
- add Mongoose schemas for permissions and roles, including status flags and references
- expose private CRUD controllers, services, and DTOs for permissions and roles with pagination support and Swagger metadata
- register the new private modules within the application module so they are available through the API

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5d2c3e3e8832ba6a79f7d6f7e965d