### PR TITLE
feat: allow filtering dashboard geo feedbacks

### DIFF
--- a/src/private/dashboard/dashboard.controller.ts
+++ b/src/private/dashboard/dashboard.controller.ts
@@ -1,11 +1,14 @@
-import { Controller, Get, Req } from '@nestjs/common';
+import { Controller, Get, Query, Req } from '@nestjs/common';
 import {
   DashboardService,
   DashboardSummaryResponseDto,
 } from './dashboard.service';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { Request } from 'express';
 import { JwtUserPayload } from '../../auth/interfaces/jwt-user-payload.interface';
+import { FeedbackGeoQueryDto } from './dto/feedback-geo-query.dto';
+import { FeedbackType } from '../../modules/feedback/feedback-type.enum';
+import { FeedbackStatus } from '../../modules/feedback/feedback-status.enum';
 
 type RequestWithUser = Request & { user: JwtUserPayload };
 
@@ -25,9 +28,12 @@ export class DashboardController {
   }
 
   @Get('feedbacks/geo')
+  @ApiQuery({ name: 'type', required: false, enum: FeedbackType })
+  @ApiQuery({ name: 'status', required: false, enum: FeedbackStatus })
   async getFeedbacksGeo(
     @Req() req: RequestWithUser,
+    @Query() filters: FeedbackGeoQueryDto,
   ): Promise<{ latitude: number; longitude: number }[]> {
-    return this.dashboardService.getFeedbacksGeo(req.user);
+    return this.dashboardService.getFeedbacksGeo(req.user, filters);
   }
 }

--- a/src/private/dashboard/dto/feedback-geo-query.dto.ts
+++ b/src/private/dashboard/dto/feedback-geo-query.dto.ts
@@ -1,0 +1,19 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsOptional } from 'class-validator';
+import { FeedbackType } from '../../../modules/feedback/feedback-type.enum';
+import { FeedbackStatus } from '../../../modules/feedback/feedback-status.enum';
+
+export class FeedbackGeoQueryDto {
+  @ApiPropertyOptional({ enum: FeedbackType, description: 'Tipo de feedback' })
+  @IsOptional()
+  @IsEnum(FeedbackType)
+  type?: FeedbackType;
+
+  @ApiPropertyOptional({
+    enum: FeedbackStatus,
+    description: 'Estado del feedback',
+  })
+  @IsOptional()
+  @IsEnum(FeedbackStatus)
+  status?: FeedbackStatus;
+}


### PR DESCRIPTION
## Summary
- add a DTO that captures optional query filters for the dashboard geo feedback endpoint
- update the dashboard controller to validate and document optional type and status filters
- extend the dashboard service to apply the optional filters when retrieving geo-coordinates

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d9e6eef020832bb72b828bca1af078